### PR TITLE
Made parsing robust to the rdf & dc namespacing used by craigslist

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -75,8 +75,8 @@ function isRSS(json){
 
 // normalizes input to make feed burner work
 function normalize(json) {
-  if (json.rss) {
-    return json.rss;
+  if (json.rss || json['rdf:RDF']) {
+    return json.rss || json['rdf:RDF'];
   }
   return json;
 }
@@ -100,6 +100,7 @@ function formatRSS(json){
 	//Start with the metadata for the feed
 	var metadata = {};
 	var channel = json.channel;
+  var items = json.item || channel.item;
 
   if (_.isArray(json.channel)) {
     channel = json.channel[0];
@@ -124,13 +125,14 @@ function formatRSS(json){
 		metadata.ttl = channel.ttl;
 	}
 	output.metadata = metadata;
+
 	//ok, now lets get into the meat of the feed
 	//just double check that it exists
-	if(channel.item){
-		if(!_.isArray(channel.item)){
-			channel.item = [channel.item];
+	if(items){
+		if(!_.isArray(items)){
+			items = [items];
 		}
-		_.each(channel.item, function(val, index){
+		_.each(items, function(val, index){
 			val = flattenComments(val);
 			var obj = {};
 			obj.title = val.title;
@@ -140,9 +142,9 @@ function formatRSS(json){
 				obj.category = val.category;
 			}
 			//since we are going to format the date, we want to make sure it exists
-			if(val.pubDate){
+			if(val.pubDate || val['dc:date']){
 				//lets try basis js date parsing for now
-				obj.date = Date.parse(val.pubDate);
+				obj.date = Date.parse(val.pubDate || val['dc:date']);
 			}
 			//now lets handel the GUID
 			if(val.guid){

--- a/test/test.js
+++ b/test/test.js
@@ -60,5 +60,39 @@ vows.describe('bindparser').addBatch({
         assert.isNull(docs);
       }
     }
+  },
+  'craigslist':{
+    topic: function () {
+      parser.parseURL('http://portland.craigslist.org/sof/index.rss', this.callback);
+    },
+    'response is formatted as rss': function (err, docs) {
+      assert.equal(docs.type, 'rss');
+      assert.isObject(docs.metadata);
+      assert.isArray(docs.items);
+    },
+    'response contains items': function (err, docs) {
+      assert.isArray(docs.items);
+      assert.ok(docs.items.length > 0);
+    },
+    'response items have titles': function (err, docs) {
+      assert.isArray(docs.items);
+      assert.ok(docs.items.length > 0);
+      assert.isNotNull(docs.items[0].title);
+    },
+    'response items have links': function (err, docs) {
+      assert.isArray(docs.items);
+      assert.ok(docs.items.length > 0);
+      assert.isNotNull(docs.items[0].link);
+    },
+    'response items have desc': function (err, docs) {
+      assert.isArray(docs.items);
+      assert.ok(docs.items.length > 0);
+      assert.isNotNull(docs.items[0].desc);
+    },
+    'response items have date': function (err, docs) {
+      assert.isArray(docs.items);
+      assert.ok(docs.items.length > 0);
+      assert.isNotNull(docs.items[0].date);
+    }
   }
 }).export(module);


### PR DESCRIPTION
Before these code changes a URL like http://portland.craigslist.org/sof/index.rss was being identified as atom and had no items listed. I added test coverage. Thanks for authoring the library!
