### PR TITLE
Items not being grabbed when channel comes back as array

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -100,11 +100,12 @@ function formatRSS(json){
 	//Start with the metadata for the feed
 	var metadata = {};
 	var channel = json.channel;
-  var items = json.item || channel.item;
 
   if (_.isArray(json.channel)) {
     channel = json.channel[0];
   }
+
+  var items = json.item || channel.item;
 
 	if(channel.title){
 		metadata.title = channel.title;

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,10 @@ vows.describe('bindparser').addBatch({
       assert.equal(docs.type, 'rss');
       assert.isObject(docs.metadata);
       assert.isArray(docs.items);
+    },
+    'response contains items':function(err, docs) {
+      assert.isArray(docs.items);
+      assert.ok(docs.items.length > 0);
     }
   },
   'oddities':{


### PR DESCRIPTION
I noticed that sometimes the channel value comes back as an array. When that happens channel get's reset but the items are not set accordingly. I updated the test and code to work with this particular instance.
