### PR TITLE
More robust parsing of RSS and atom feeds

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -87,10 +87,82 @@ function flattenComments(json) {
   return json;
 }
 
+//parse a title from the channel
+function getTitle(title) {
+  if (_.isArray(title)) {
+    title = _.first(title);
+  }
+  if (_.isObject(title) && _.isString(title._)) {
+    title = title._
+  }
+  return title;
+}
+
+//parse a desc from the channel
+function getDesc(desc) {
+  if (_.isArray(desc)) {
+    desc = _.first(desc);
+  }
+  if (_.isObject(desc) && _.isString(desc._)) {
+    desc = desc._;
+  }
+  return desc;
+}
+
+//parse a link from the channel
+function getURL(link) {
+  var url = '';
+  if (link) {
+    if (_.isArray(link)) {
+      // You'll get the alt link or the last link defined
+      _.each(link, function(val, i) {
+        if (val.$ && val.$.rel == 'alternate') {
+          url = val.$.href;
+          return false;
+        }
+        else if (val.rel == 'alternate') {
+          url = val.href;
+          return false;
+        }
+        else {
+          url = val;
+        }
+      });
+    } else if (_.isObject(link)) {
+      url = link.$ && link.$.href || link.href;
+    } else {
+      url = link;
+    }
+  }
+  return url;
+}
+
+//parse categories from the channel
+function getCategories(category) {
+  var categories = [];
+  if (category) {
+    if (_.isArray(category)) {
+      _.each(category, function(val, i) {
+        if (_.isObject(val) && _.isString(val._)) {
+          categories.push(val._);
+        } else {
+          categories.push(val);
+        }
+      });
+    } else if (_.isObject(category) && _.isString(category._)) {
+      categories.push(category._);
+    } else {
+      categories.push(category);
+    }
+  }
+  return categories;
+}
+
 //formats the RSS feed to the needed outpu
 //also parses FeedBurner
 function formatRSS(json) {
   var output = {'type': 'rss', metadata: {}, items: []};
+
   //Start with the metadata for the feed
   var metadata = {};
   var channel = json.channel;
@@ -99,44 +171,57 @@ function formatRSS(json) {
     channel = json.channel[0];
   }
 
-  var items = json.item || channel.item;
-
+  //Channel title
   if (channel.title) {
-    metadata.title = channel.title;
+    metadata.title = getTitle(channel.title);
   }
+
+  //Channel description
   if (channel.description) {
-    metadata.desc = channel.description;
+    metadata.desc = getDesc(channel.description);
   }
+
+  //Channel URL
   if (channel.link) {
-    metadata.url = channel.link;
+    metadata.url = getURL(channel.link);
   }
+
+  //Channel update date/time
   if (channel.lastBuildDate) {
     metadata.lastBuildDate = channel.lastBuildDate;
+    if (_.isArray(metadata.lastBuildDate)) {
+      metadata.lastBuildDate = _.first(metadata.lastBuildDate);
+    }
   }
   if (channel.pubDate) {
     metadata.update = channel.pubDate;
+    if (_.isArray(metadata.update)) {
+      metadata.update = _.first(metadata.update);
+    }
   }
   if (channel.ttl) {
     metadata.ttl = channel.ttl;
+    if (_.isArray(metadata.ttl)) {
+      metadata.ttl = _.first(metadata.ttl);
+    }
   }
 
+  //Channel image info
   if (channel.image) {
-
     metadata.image = [];
-
     channel.image.forEach(function(image, index) {
       metadata.image[index] = {};
       Object.keys(image).forEach(function(attr) {
-        metadata.image[index][attr] = image[attr];
+        metadata.image[index][attr] = _.isArray(image[attr]) ? _.first(image[attr]) : image[attr];
       });
     });
-
   }
 
   output.metadata = metadata;
 
   //ok, now lets get into the meat of the feed
   //just double check that it exists
+  var items = json.item || channel.item;
   if (items) {
     if (!_.isArray(items)) {
       items = [items];
@@ -144,36 +229,58 @@ function formatRSS(json) {
     _.each(items, function(val, index) {
       val = flattenComments(val);
       var obj = {};
-      obj.title = val.title;
-      obj.desc = val.description;
-      obj.link = val.link;
-      if (val.category) {
-        obj.category = val.category;
-      }
+      //item title/desc/etc.
+      obj.title = getTitle(val.title);
+      obj.desc = getDesc(val.description);
+      obj.link = getURL(val.link);
+      obj.category = getCategories(val.category);
+
       //since we are going to format the date, we want to make sure it exists
-      if (val.pubDate || val['dc:date']) {
-        //lets try basis js date parsing for now
-        obj.date = Date.parse(val.pubDate || val['dc:date']);
+      var pubDate = val.pubDate || val['dc:date'];
+      if (pubDate) {
+        if (_.isArray(pubDate)) {
+          pubDate = _.first(pubDate);
+        }
+        //lets try basic js date parsing for now
+        obj.date = Date.parse(pubDate);
       }
+
       //now lets handel the GUID
       if (val.guid) {
-        //xml2js parses this kina odd...
         var link = val.guid;
         var isPermaLink = true;
-        //if(param){
-        //  isPermaLink = param.isPermaLink;
-        //}
+        if (_.isArray(link)) {
+          link = _.first(link);
+        }
+        if (_.isObject(link) && _.isString(link._)) {
+          link = link._;
+        }
         obj.guid = {'link': link, isPermaLink: isPermaLink};
       }
 
-      //Check for images
+      //grab media content if exists
       if (val['media:content']) {
-          obj.media = val.media || {};
-          obj.media.content = val['media:content'];
+        var content = val['media:content'];
+        if (_.isArray(content)) {
+          content = _.first(content);
+        }
+        if (_.isObject(content) && content.$) {
+          content = content.$;
+        }
+        obj.media = val.media || {};
+        obj.media.content = content;
       }
+      //grab thumbnail if exists
       if (val['media:thumbnail']) {
-          obj.media = val.media || {};
-          obj.media.thumbnail = val['media:content'];
+        var thumbnail = val['media:thumbnail'];
+        if (_.isArray(thumbnail)) {
+          thumbnail = _.first(thumbnail);
+        }
+        if (_.isObject(thumbnail) && thumbnail.$) {
+          thumbnail = thumbnail.$;
+        }
+        obj.media = val.media || {};
+        obj.media.thumbnail = thumbnail;
       }
       //now push the obj onto the stack
       output.items.push(obj);
@@ -183,29 +290,61 @@ function formatRSS(json) {
 }
 
 //formats the ATOM feed to the needed output
-//yes, this is a shamless copy-pasta of the RSS code (its all the same structure!)
 function formatATOM(json) {
   var output = {'type': 'atom', metadata: {}, items: []};
+
   //Start with the metadata for the feed
   var metadata = {};
   var channel = json.feed || json;
+
+  //Channel title
   if (channel.title) {
-    metadata.title = channel.title;
+    metadata.title = getTitle(channel.title);
   }
+
+  //Channel description
   if (channel.subtitle) {
-    metadata.desc = channel.subtitle;
+    metadata.desc = getDesc(channel.subtitle);
   }
+
+  //Channel URL
   if (channel.link) {
-    metadata.url = channel.link;
+    metadata.url = getURL(channel.link);
   }
+
+  //Channel id
   if (channel.id) {
     metadata.id = channel.id;
+    if (_.isArray(metadata.id)) {
+      metadata.id = _.first(metadata.id);
+    }
   }
-  if (channel.update) {
-    metadata.update = channel.update;
+
+  //Channel update date/time
+  if (channel.updated) {
+    metadata.update = channel.updated;
+    if (_.isArray(metadata.update)) {
+      metadata.update = _.first(metadata.update);
+    }
   }
+
+  //Channel author info
   if (channel.author) {
     metadata.author = channel.author;
+    if (_.isArray(metadata.author)) {
+      metadata.author = _.first(metadata.author);
+    }
+    if (_.isObject(metadata.author)) {
+      _.each(metadata.author, function(val, prop) {
+        if (_.isArray(val)) {
+          val = _.first(val);
+        }
+        if (_.isObject(val) && val.$) {
+          val = val.$;
+        }
+        metadata.author[prop] = val;
+      });
+    }
   }
 
   output.metadata = metadata;
@@ -217,59 +356,61 @@ function formatATOM(json) {
     _.each(channel.entry, function(val, index) {
       val = flattenComments(val);
       var obj = {};
+      //item id
       obj.id = val.id;
+      if (_.isArray(obj.id)) {
+        obj.id = _.first(obj.id);
+      }
+
+      //item title/desc/etc.
       if (!val.title) {
         console.log(json);
       }
-      obj.title = val.title;
-      if (val.content) {
-        obj.desc = val.content;
-      } else if (val.summary) {
-        obj.desc = val.summary;
-      }
-      var categories = [];
-      //just grab the category text
-      if (val.category) {
-        if (_.isArray(val.category)) {
-          _.each(val.category, function(val, i) {
-            categories.push(val['term']);
-          });
-        } else {
-          categories.push(val.category);
-        }
-      }
-      obj.category = categories;
-      var link = '';
-      //just get the alternate link
-      if (val.link) {
-        if (_.isArray(val.link)) {
-          _.each(val.link, function(val, i) {
-            if (val.rel == 'alternate') {
-              link = val.href;
-            }
-          });
-        } else {
-          link = val.link.href;
-        }
-      }
-      obj.link = link;
+      obj.title = getTitle(val.title);
+      obj.desc = getDesc(val.content || val.summary);
+      obj.link = getURL(val.link);
+      obj.category = getCategories(val.category);
+
       //since we are going to format the date, we want to make sure it exists
-      if (val.published) {
-        //lets try basis js date parsing for now
-        obj.date = Date.parse(val.published);
+      var pubDate = val.published || val.pubDate;
+      if (pubDate) {
+        if (_.isArray(pubDate)) {
+          pubDate = _.first(pubDate);
+        }
+        //lets try basic js date parsing for now
+        obj.date = Date.parse(pubDate);
       }
       if (val.updated) {
-        //lets try basis js date parsing for now
+        if (_.isArray(val.updated)) {
+          val.updated = _.first(val.updated);
+        }
+        //lets try basic js date parsing for now
         obj.updated = Date.parse(val.updated);
       }
+
       //grab thumbnail if exists
       if (val['media:thumbnail']) {
-          obj.media = val.media || {};
-          obj.media.thumbnail = val['media:content'];
-      } //grab media content if exists
+        var thumbnail = val['media:thumbnail'];
+        if (_.isArray(thumbnail)) {
+          thumbnail = _.first(thumbnail);
+        }
+        if (_.isObject(thumbnail) && thumbnail.$) {
+          thumbnail = thumbnail.$;
+        }
+        obj.media = val.media || {};
+        obj.media.thumbnail = thumbnail;
+      }
+      //grab media content if exists
       if (val['media:content']) {
-          obj.media = val.media || {};
-          obj.media.content = val['media:content'];
+        var content = val['media:content'];
+        if (_.isArray(content)) {
+          content = _.first(content);
+        }
+        if (_.isObject(content) && content.$) {
+          content = content.$;
+        }
+        obj.media = val.media || {};
+        obj.media.content = content;
       }
       //now push the obj onto the stack
       output.items.push(obj);
@@ -277,5 +418,3 @@ function formatATOM(json) {
   }
   return output;
 }
-
-

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -116,11 +116,11 @@ function getURL(link) {
     if (_.isArray(link)) {
       // You'll get the alt link or the last link defined
       _.each(link, function(val, i) {
-        if (val.$ && val.$.rel == 'alternate') {
+        if (val.$ && val.$.rel === 'alternate') {
           url = val.$.href;
           return false;
         }
-        else if (val.rel == 'alternate') {
+        else if (val.rel === 'alternate') {
           url = val.href;
           return false;
         }
@@ -128,6 +128,9 @@ function getURL(link) {
           url = val;
         }
       });
+      if (_.isObject(url)) {
+        url = url.$ && url.$.href || url.href;
+      }
     } else if (_.isObject(link)) {
       url = link.$ && link.$.href || link.href;
     } else {

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,25 @@ vows.describe('bindparser').addBatch({
     'response is properly formatted': function(err, docs) {
       assert.equal(docs.type, 'rss');
       assert.isObject(docs.metadata);
+      assert.isString(docs.metadata.title);
+      assert.isString(docs.metadata.desc);
+      assert.isString(docs.metadata.url);
+      assert.isString(docs.metadata.lastBuildDate);
+      assert.isString(docs.metadata.update);
+      assert.isString(docs.metadata.ttl);
+      assert.isArray(docs.metadata.image);
+    },
+    'response contains items': function(err, docs) {
       assert.isArray(docs.items);
+      assert.ok(docs.items.length > 0);
+      var item = docs.items[0];
+      assert.isString(item.title);
+      assert.isString(item.desc);
+      assert.isArray(item.category);
+      assert.isString(item.link);
+      assert.isNumber(item.date);
+      assert.isObject(item.guid);
+      assert.isString(item.guid.link);
     }
   },
   'atom tests': {
@@ -31,11 +49,26 @@ vows.describe('bindparser').addBatch({
     'response is properly formatted': function(err, docs) {
       assert.equal(docs.type, 'atom');
       assert.isObject(docs.metadata);
-      assert.isArray(docs.items);
+      assert.isString(docs.metadata.title);
+      assert.isString(docs.metadata.desc);
+      assert.isString(docs.metadata.url);
+      assert.isString(docs.metadata.id);
+      assert.isString(docs.metadata.update);
+      assert.isObject(docs.metadata.author);
     },
     'response contains items': function(err, docs) {
       assert.isArray(docs.items);
       assert.ok(docs.items.length > 0);
+      var item = docs.items[0];
+      assert.isString(item.id);
+      assert.isString(item.title);
+      assert.isString(item.desc);
+      assert.isArray(item.category);
+      assert.isString(item.link);
+      assert.isNumber(item.date);
+      assert.isNumber(item.updated);
+      assert.isObject(item.media);
+      assert.isObject(item.media.thumbnail);
     }
   },
   'feedburner tests': {

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,34 @@ vows.describe('bindparser').addBatch({
       assert.isObject(item.media.thumbnail);
     }
   },
+  'additional atom tests': {
+    topic: function() {
+      parser.parseURL('http://code.visualstudio.com/feed.xml', {}, this.callback);
+    },
+    'response is not null': function(err, docs) {
+      assert.isNull(err);
+      assert.isNotNull(docs);
+    },
+    'response is properly formatted': function(err, docs) {
+      assert.equal(docs.type, 'atom');
+      assert.isObject(docs.metadata);
+      assert.isString(docs.metadata.title);
+      assert.isString(docs.metadata.url);
+      assert.isString(docs.metadata.id);
+      assert.isString(docs.metadata.update);
+    },
+    'response contains items': function(err, docs) {
+      assert.isArray(docs.items);
+      assert.ok(docs.items.length > 0);
+      var item = docs.items[0];
+      assert.isString(item.id);
+      assert.isString(item.title);
+      assert.isString(item.desc);
+      assert.isArray(item.category);
+      assert.isString(item.link);
+      assert.isNumber(item.updated);
+    }
+  },
   'feedburner tests': {
     topic: function() {
       parser.parseURL('http://feeds.feedburner.com/TechCrunch', this.callback);


### PR DESCRIPTION
This is a general update to parsing of both Atom and RSS feeds that aligns the output of xml2js more accurately with the expected output reported in the docs.

e.g. A <title> is typically an array, it could be an array of one string item or an array of one object with a "_" property that is the text node.

I've tried to make the refactor more DRY as well, and I've added some tests to the CNN and Google Blog tests checking types for the various attributes expected in the parsed return.

Let me know if you have any questions, and I appreciate your work on this project!

Thanks,
Eric